### PR TITLE
feat(mcp-server): mcp server plugin support errorResponseTemplate to customize response when backend http status greater than 300 (#2330)

### DIFF
--- a/pkg/mcp/server/rest_server.go
+++ b/pkg/mcp/server/rest_server.go
@@ -930,8 +930,12 @@ func (t *RestMCPTool) Call(httpCtx HttpContext, server Server) error {
 
 			if statusCode >= 300 || statusCode < 200 {
 				if t.toolConfig.parsedErrorResponseTemplate != nil {
-					//Error response template is provided to customize the error response result.
-					//Based on the responseBody, access the map-structured responseHeaders through _headers to reference their values within the errorResponseTemplate.
+					// Error response template is provided to customize the error response result.
+					// Based on the responseBody, access the map-structured responseHeaders through _headers to reference their values within the errorResponseTemplate.
+					// Usage examples in errorResponseTemplate:
+					// - {{gjson "_headers.\\:status"}} -> Get HTTP status code
+					// - {{gjson "_headers.x-ca-error-code"}} -> Get value of header key "x-ca-error-code"
+					// - {{.data.value}} -> Access original responseBody content (e.g., JSON field "data.value")
 					errorResponseTemplateDataBytes, _ := sjson.SetBytes(responseBody, "_headers", convertHeaders(responseHeaders))
 					errorTemplateResult, err := executeTemplate(t.toolConfig.parsedErrorResponseTemplate, errorResponseTemplateDataBytes)
 					if err != nil {


### PR DESCRIPTION
feat(mcp-server): mcp server plugin support errorResponseTemplate to customize response when backend http status greater than 300 (#2330)