### PR TITLE
fix(tokenusage): Fixed the issue where the openai/v1/responses API could not count tokens after SSE messages were truncated due to a large amount of data

### DIFF
--- a/pkg/tokenusage/tokenusage.go
+++ b/pkg/tokenusage/tokenusage.go
@@ -86,6 +86,9 @@ const (
 
 	OutputTokenDetailsKeyDoubaoGeneratedImages    = "generated_images"
 	OutputTokenDetailsKeyGeminiThoughtsTokenCount = "thoughts_token_count"
+
+	ctxKeyDeltaSSEMessage = "delta_sse_message"
+	ctxKeyDeltaBeginning  = "delta_beginning"
 )
 
 type TokenUsage struct {
@@ -102,7 +105,7 @@ type TokenUsage struct {
 }
 
 func GetTokenUsage(ctx wrapper.HttpContext, body []byte) TokenUsage {
-	chunks := bytes.SplitSeq(bytes.TrimSpace(wrapper.UnifySSEChunk(body)), []byte("\n\n"))
+	chunks := bytes.SplitSeq(wrapper.UnifySSEChunk(body), []byte("\n\n"))
 	u := TokenUsage{
 		InputTokenDetails:  make(map[string]int64),
 		OutputTokenDetails: make(map[string]int64),
@@ -110,6 +113,24 @@ func GetTokenUsage(ctx wrapper.HttpContext, body []byte) TokenUsage {
 	for chunk := range chunks {
 		// the feature strings are used to identify the usage data, like:
 		// {"model":"gpt2","usage":{"prompt_tokens":1,"completion_tokens":1}}
+
+		// openai /v1/responses
+		if bytes.Contains(chunk, []byte(`"response.completed"`)) && !bytes.Contains(chunk, []byte(`"usage"`)) {
+			ctx.SetContext(ctxKeyDeltaBeginning, true)
+		}
+
+		if ctx.GetBoolContext(ctxKeyDeltaBeginning, false) {
+			// end of streaming
+			if len(bytes.TrimSpace(body)) == 0 {
+				ctx.SetContext(ctxKeyDeltaBeginning, false)
+				chunk = ctx.GetByteSliceContext(ctxKeyDeltaSSEMessage, chunk)
+				ctx.SetContext(ctxKeyDeltaSSEMessage, nil)
+			} else {
+				deltaMessage := ctx.GetByteSliceContext(ctxKeyDeltaSSEMessage, []byte{})
+				deltaMessage = append(deltaMessage, chunk...)
+				ctx.SetContext(ctxKeyDeltaSSEMessage, deltaMessage)
+			}
+		}
 
 		if !bytes.Contains(chunk, []byte(`"usage"`)) && !bytes.Contains(chunk, []byte(`"usageMetadata"`)) {
 			continue


### PR DESCRIPTION
调用 responses 接口时，如果数据量比较大(比如编码工具)的时候会将单条 JSON 数据拆分成多条返回
所以这里得要对最后一条包含 Token 信息的数据(type: response.completed)进行数据合并后再统计