### PR TITLE
check log level ahead

### DIFF
--- a/pkg/test/host.go
+++ b/pkg/test/host.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -131,6 +132,13 @@ func NewTestHostWithForeignFuncs(config json.RawMessage, foreignFuncs map[string
 	for name, f := range foreignFuncs {
 		host.RegisterForeignFunction(name, f)
 	}
+
+	host.RegisterForeignFunction("get_log_level", func(b []byte) []byte {
+		var val uint32 = 0
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, val)
+		return buf
+	})
 
 	// start the plugin.
 	status := host.StartPlugin()

--- a/pkg/wrapper/log_wrapper.go
+++ b/pkg/wrapper/log_wrapper.go
@@ -41,7 +41,6 @@ func (l *DefaultLog) log(level LogLevel, msg string) {
 	value, err := proxywasm.CallForeignFunction("get_log_level", nil)
 	var envoyLogLevel LogLevel
 	if err != nil {
-		proxywasm.LogErrorf("failed to call foreign function: %v", err)
 		envoyLogLevel = LogLevelTrace
 	} else {
 		envoyLogLevel = LogLevel(binary.LittleEndian.Uint32(value))
@@ -75,7 +74,6 @@ func (l *DefaultLog) logFormat(level LogLevel, format string, args ...interface{
 	value, err := proxywasm.CallForeignFunction("get_log_level", nil)
 	var envoyLogLevel LogLevel
 	if err != nil {
-		proxywasm.LogErrorf("failed to call foreign function: %v", err)
 		envoyLogLevel = LogLevelTrace
 	} else {
 		envoyLogLevel = LogLevel(binary.LittleEndian.Uint32(value))


### PR DESCRIPTION
在 Wasm 堆内存执行分配逻辑前进行条件判断，实现日志前置拦截，避免非必要内存开销