### PR TITLE
fix: escape newlines in panic stack trace for better log collection

### DIFF
--- a/pkg/wrapper/plugin_wrapper.go
+++ b/pkg/wrapper/plugin_wrapper.go
@@ -1259,6 +1259,9 @@ func recoverFunc() {
 		const size = 64 << 10
 		buf := make([]byte, size)
 		buf = buf[:runtime.Stack(buf, false)]
-		log.Errorf("recovered from panic %v, stack: %s", r, buf)
+		// Escape newlines to ensure the entire stack trace is printed on a single line,
+		// which prevents log collection systems from splitting the stack trace into multiple entries
+		escapedStack := strings.ReplaceAll(string(buf), "\n", "\\n")
+		log.Errorf("recovered from panic %v, stack: %s", r, escapedStack)
 	}
 }


### PR DESCRIPTION
## Problem

When a panic occurs in a plugin, `recoverFunc` captures and logs the stack trace. However, the stack trace contains newlines that cause log collection systems (such as ELK, Loki, etc.) to split a single panic event into multiple log entries, making it difficult to correlate and analyze.

## Solution

Escape newlines (`\n` -> `\\n`) in the stack trace before logging, ensuring the entire panic information is captured in a single log line for better log collection and analysis.

## Changes

```go
// Before
log.Errorf("recovered from panic %v, stack: %s", r, buf)

// After
escapedStack := strings.ReplaceAll(string(buf), "\n", "\\n")
log.Errorf("recovered from panic %v, stack: %s", r, escapedStack)
```

## Example Output

After this change, the log output will look like:
```
[error] recovered from panic test panic, stack: goroutine 1 [running]:\nmain.testFunc()\n\t/app/main.go:10 +0x45\nmain.main()\n\t/app/main.go:5 +0x20\n
```