### PR TITLE
fix(mcp-server): handle DELETE request for session termination per MCP spec

### DIFF
--- a/pkg/mcp/server/plugin.go
+++ b/pkg/mcp/server/plugin.go
@@ -764,6 +764,15 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config McpServerConfig) types
 		proxywasm.SendHttpResponseWithDetail(405, "not_support_sse_on_this_endpoint", nil, nil, -1)
 		return types.HeaderStopAllIterationAndWatermark
 	}
+	// Handle DELETE request for session termination (MCP 2025-06-18 spec)
+	// Per spec: "Clients that no longer need a particular session SHOULD send an HTTP DELETE
+	// to the MCP endpoint with the Mcp-Session-Id header, to explicitly terminate the session."
+	// Per spec: "The server MAY respond to this request with HTTP 405 Method Not Allowed,
+	// indicating that the server does not allow clients to terminate sessions."
+	if ctx.Method() == "DELETE" {
+		proxywasm.SendHttpResponseWithDetail(405, "session_termination_not_supported", nil, nil, -1)
+		return types.HeaderStopAllIterationAndWatermark
+	}
 	if !ctx.HasRequestBody() {
 		proxywasm.SendHttpResponseWithDetail(400, "missing_body_in_mcp_request", nil, nil, -1)
 		return types.HeaderStopAllIterationAndWatermark


### PR DESCRIPTION
## Problem

When MCP clients disconnect from a session, they send an HTTP DELETE request to the MCP endpoint (per MCP 2025-06-18 spec). Currently, the mcp-server plugin returns `400 Bad Request` for DELETE requests because they don't have a body, which violates the MCP protocol.

## MCP Specification Reference

From [MCP 2025-06-18 Transports Specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports):

> Clients that no longer need a particular session (e.g., because the user is leaving the client application) SHOULD send an HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header, to explicitly terminate the session.
>
> The server MAY respond to this request with HTTP 405 Method Not Allowed, indicating that the server does not allow clients to terminate sessions.

## Solution

Add explicit handling for DELETE requests before the body check:
- Return `405 Method Not Allowed` with detail `session_termination_not_supported`
- This is a spec-compliant response indicating the server doesn't support client-initiated session termination

## Changes

- `pkg/mcp/server/plugin.go`: Add DELETE method handling in `onHttpRequestHeaders`