### PR TITLE
fix: handle Redis "unauthenticated multibulk length" error with re-auth retry

### DIFF
--- a/pkg/wrapper/redis_wrapper.go
+++ b/pkg/wrapper/redis_wrapper.go
@@ -199,12 +199,18 @@ func redisCallInternal(cluster Cluster, respQuery []byte, callback RedisResponse
 				}
 			}
 
-			// Check for NOAUTH error and retry if possible
+			// Check for authentication error and retry if possible.
+			// Redis may return "NOAUTH Authentication required" or
+			// "ERR Protocol error: unauthenticated multibulk length" when
+			// the underlying TCP connection has been recycled (e.g. after an
+			// Envoy cluster config update that drains the connection pool)
+			// and the new connection lacks AUTH state.
 			shouldInvokeCallback := true
 			if responseValue.Error() != nil && readyPtr != nil && checkReadyFunc != nil {
 				errMsg := responseValue.Error().Error()
-				if bytes.Contains([]byte(errMsg), []byte("NOAUTH Authentication required")) {
-					proxywasm.LogWarnf("redis authentication required, request-id: %s, marking client as not ready and attempting re-authentication", requestID)
+				if bytes.Contains([]byte(errMsg), []byte("NOAUTH Authentication required")) ||
+					bytes.Contains([]byte(errMsg), []byte("unauthenticated")) {
+					proxywasm.LogWarnf("redis authentication lost, request-id: %s, error: %s, marking client as not ready and attempting re-authentication", requestID, errMsg)
 					*readyPtr = false
 
 					// Try to re-authenticate


### PR DESCRIPTION
## Summary

- Broadens the Redis authentication error detection in `redisCallInternal` to also match `"unauthenticated"` keyword, in addition to the existing `"NOAUTH Authentication required"` check.
- This fixes a bug where Redis connections silently lose AUTH state after Envoy cluster config updates (e.g. `upstreamIdleTimeout` changes), causing `ERR Protocol error: unauthenticated multibulk length` errors that were not caught by the existing retry logic.

## Background

When Envoy gateway configuration changes (such as updating `upstreamIdleTimeout` which modifies `HttpProtocolOptions.common_http_protocol_options.idle_timeout` on all clusters), the cluster connection pool may be drained and recreated. The new TCP connections to Redis lack the AUTH state that was established during `RedisInit()`.

Redis 6+ has a security feature where it refuses to parse RESP commands from unauthenticated clients, returning `ERR Protocol error: unauthenticated multibulk length` instead of the more common `NOAUTH Authentication required`. The existing retry logic in `redis_wrapper.go` only checked for the latter, so this error variant bypassed the automatic re-authentication mechanism.

## Changes

In `pkg/wrapper/redis_wrapper.go`, the error matching condition is changed from:

```go
if bytes.Contains([]byte(errMsg), []byte("NOAUTH Authentication required")) {
```

to:

```go
if bytes.Contains([]byte(errMsg), []byte("NOAUTH Authentication required")) ||
    bytes.Contains([]byte(errMsg), []byte("unauthenticated")) {
```

## Test plan

- [ ] Verify that `NOAUTH Authentication required` errors still trigger re-auth retry (existing behavior preserved)
- [ ] Verify that `ERR Protocol error: unauthenticated multibulk length` errors now also trigger re-auth retry
- [ ] Verify that unrelated Redis errors are not affected by this change


Made with [Cursor](https://cursor.com)